### PR TITLE
Refactor `futex_wake` to avoid `clock_gettime` dependencies

### DIFF
--- a/src/futex.rs
+++ b/src/futex.rs
@@ -2,7 +2,7 @@
 //! library/std/src/sys/unix/locks/futex_mutex.rs at revision
 //! 98815742cf2e914ee0d7142a02322cf939c47834.
 
-use super::wait_wake::{futex_wait, futex_wake};
+use super::wait_wake::{futex_wait_timespec, futex_wake};
 use core::sync::atomic::{
     AtomicU32,
     Ordering::{Acquire, Relaxed, Release},
@@ -61,7 +61,7 @@ impl Mutex {
             }
 
             // Wait for the futex to change state, assuming it is still 2.
-            futex_wait(&self.futex, 2, None);
+            futex_wait_timespec(&self.futex, 2, None);
 
             // Spin again after waking up.
             state = self.spin();

--- a/src/futex_rwlock.rs
+++ b/src/futex_rwlock.rs
@@ -2,7 +2,7 @@
 //! library/std/src/sys/unix/locks/futex_rwlock.rs at revision
 //! 98815742cf2e914ee0d7142a02322cf939c47834.
 
-use super::wait_wake::{futex_wait, futex_wake, futex_wake_all};
+use super::wait_wake::{futex_wait_timespec, futex_wake, futex_wake_all};
 use core::sync::atomic::{
     AtomicU32,
     Ordering::{Acquire, Relaxed, Release},
@@ -148,7 +148,7 @@ impl RwLock {
             }
 
             // Wait for the state to change.
-            futex_wait(&self.state, state | READERS_WAITING, None);
+            futex_wait_timespec(&self.state, state | READERS_WAITING, None);
 
             // Spin again after waking up.
             state = self.spin_read();
@@ -236,7 +236,7 @@ impl RwLock {
             }
 
             // Wait for the state to change.
-            futex_wait(&self.writer_notify, seq, None);
+            futex_wait_timespec(&self.writer_notify, seq, None);
 
             // Spin again after waking up.
             state = self.spin_write();


### PR DESCRIPTION
Refactor a helper function out of `futex_wake` and use it when we don't need a timeout, so that users of `Mutex` and `RwLock` don't statically depend on `clock_gettime`.