### PR TITLE
Make some guarantees about the `repr` of `Once`, `RawMutex`, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ to provide most of the public API.
 
 `lock_api` does not support poisoning, so support for poisoning is omitted.
 
+In this library, `Condvar`, `RawCondvar`, `RawMutex`, and `Once` are guaranteed
+to be `repr(transparent)` wrappers around a single `AtomicU32`. `RawRwLock` is
+guaranteed to be a `repr(C)` wrapper around two `AtomicU32`s. The contents of
+these `AtomicU32`s are not documented, except that all these types'
+`const fn new()` and `INIT` initialize them to all zeros.
+
 [`Mutex`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/type.Mutex.html
 [`RwLock`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/type.RwLock.html
 [`Condvar`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/type.Condvar.html

--- a/src/futex_condvar.rs
+++ b/src/futex_condvar.rs
@@ -10,6 +10,7 @@ use lock_api::RawMutex as _;
 
 pub type MovableCondvar = Condvar;
 
+#[repr(transparent)]
 pub struct Condvar {
     // The value of this atomic is simply incremented on every notification.
     // This is used by `.wait()` to not miss any notifications after

--- a/src/futex_mutex.rs
+++ b/src/futex_mutex.rs
@@ -10,6 +10,7 @@ use super::wait_wake::{futex_wait_timespec, futex_wake};
 
 pub type MovableMutex = Mutex;
 
+#[repr(transparent)]
 pub struct Mutex {
     /// 0: unlocked
     /// 1: locked, no other threads waiting

--- a/src/futex_once.rs
+++ b/src/futex_once.rs
@@ -73,6 +73,7 @@ impl<'a> Drop for CompletionGuard<'a> {
     }
 }
 
+#[repr(transparent)]
 pub struct Once {
     state: AtomicU32,
 }

--- a/src/futex_rwlock.rs
+++ b/src/futex_rwlock.rs
@@ -10,6 +10,7 @@ use super::wait_wake::{futex_wait_timespec, futex_wake, futex_wake_all};
 
 pub type MovableRwLock = RwLock;
 
+#[repr(C)]
 pub struct RwLock {
     // The state consists of a 30-bit reader counter, a 'readers waiting' flag, and a 'writers waiting' flag.
     // Bits 0..30:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ use futex_rwlock::MovableRwLock;
 // Encapsulate the std lock types to hide this detail.
 #[repr(transparent)]
 pub struct RawMutex(MovableMutex);
-#[repr(transparent)]
+#[repr(C)]
 pub struct RawRwLock(MovableRwLock);
 
 // Implement the raw lock traits for our wrappers.

--- a/src/once.rs
+++ b/src/once.rs
@@ -32,6 +32,7 @@ use super::futex_once as sys;
 /// });
 /// ```
 //#[stable(feature = "rust1", since = "1.0.0")]
+#[repr(transparent)]
 pub struct Once {
     inner: sys::Once,
 }

--- a/tests/repr.rs
+++ b/tests/repr.rs
@@ -1,0 +1,64 @@
+/// rustix_futex_sync documents some details of the representation of some of
+/// its public types.
+use core::mem::{align_of, size_of, transmute};
+use rustix_futex_sync::lock_api::{RawMutex as _, RawRwLock as _};
+use rustix_futex_sync::{Condvar, Once, RawCondvar, RawMutex, RawRwLock};
+
+#[test]
+fn repr_raw_mutex() {
+    assert_eq!(size_of::<RawMutex>(), size_of::<u32>());
+    assert_eq!(align_of::<RawMutex>(), align_of::<u32>());
+    unsafe {
+        assert_eq!(transmute::<RawMutex, u32>(RawMutex::INIT), 0_u32);
+    }
+}
+
+#[test]
+fn repr_raw_condvar() {
+    assert_eq!(size_of::<RawCondvar>(), size_of::<u32>());
+    assert_eq!(align_of::<RawCondvar>(), align_of::<u32>());
+    unsafe {
+        assert_eq!(transmute::<RawCondvar, u32>(RawCondvar::new()), 0_u32);
+    }
+}
+
+#[test]
+fn repr_condvar() {
+    assert_eq!(size_of::<Condvar>(), size_of::<u32>());
+    assert_eq!(align_of::<Condvar>(), align_of::<u32>());
+    unsafe {
+        assert_eq!(transmute::<Condvar, u32>(Condvar::new()), 0_u32);
+    }
+}
+
+#[test]
+fn repr_once() {
+    assert_eq!(size_of::<Once>(), size_of::<u32>());
+    assert_eq!(align_of::<Once>(), align_of::<u32>());
+    unsafe {
+        assert_eq!(transmute::<Once, u32>(Once::new()), 0_u32);
+    }
+}
+
+#[test]
+fn repr_raw_rwlock() {
+    assert_eq!(size_of::<RawRwLock>(), size_of::<[u32; 2]>());
+    assert_eq!(align_of::<RawRwLock>(), align_of::<[u32; 2]>());
+    unsafe {
+        assert_eq!(
+            transmute::<RawRwLock, [u32; 2]>(RawRwLock::INIT),
+            [0_u32; 2]
+        );
+    }
+}
+
+// Test that the types are FFI-safe.
+#[allow(dead_code)]
+#[deny(improper_ctypes)]
+extern "C" {
+    fn use_raw_mutex(x: RawMutex);
+    fn use_raw_rwlock(x: RawRwLock);
+    fn use_condvar(x: Condvar);
+    fn use_raw_condvar(x: RawCondvar);
+    fn use_once(x: Once);
+}


### PR DESCRIPTION
Make some guarantees about the `repr` of `Once`, `RawMutex`, `Condvar`, `RawCondvar`, and `RawRwLock`. Since these are always implemented in terms of Linux's futex, guarantee that they's just wrappers around `AtomicU32`s, and that they're initialized to zeros.