### PR TITLE
Minor cleanups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 
 Linux futex-based implementations of [`Mutex`], [`RwLock`], [`Condvar`],
 [`Once`], and [`OnceLock`], as well as [`RawMutex`], [`RawRwLock`], and
-[`RawCondvar`], derived from the futex code in std, factored out to
-a standalone `no_std` crate using [`rustix`] to do the futex and [`lock_api`]
-to provide most of the public API.
+[`RawCondvar`], derived from the futex code in std, factored out to a
+standalone `no_std` crate using [`rustix`] to do the futex and [`lock_api`] to
+provide most of the public `Mutex` and `RwLock` API.
 
 `lock_api` does not support poisoning, so support for poisoning is omitted.
 
@@ -29,11 +29,11 @@ these `AtomicU32`s are not documented, except that all these types'
 
 [`Mutex`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/type.Mutex.html
 [`RwLock`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/type.RwLock.html
-[`Condvar`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/type.Condvar.html
-[`Once`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/type.Once.html
-[`OnceLock`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/type.OnceLock.html
-[`RawMutex`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/type.RawMutex.html
-[`RawRwLock`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/type.RawRwLock.html
+[`Condvar`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/struct.Condvar.html
+[`Once`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/struct.Once.html
+[`OnceLock`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/struct.OnceLock.html
+[`RawMutex`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/struct.RawMutex.html
+[`RawRwLock`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/struct.RawRwLock.html
 [`RawCondvar`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/type.RawCondvar.html
 [`rustix`]: https://github.com/bytecodealliance/rustix#readme
 [`lock_api`]: https://crates.io/crates/lock_api

--- a/src/futex_condvar.rs
+++ b/src/futex_condvar.rs
@@ -8,8 +8,6 @@ use core::time::Duration;
 use super::RawMutex;
 use lock_api::RawMutex as _;
 
-pub type MovableCondvar = Condvar;
-
 #[repr(transparent)]
 pub struct Condvar {
     // The value of this atomic is simply incremented on every notification.

--- a/src/futex_mutex.rs
+++ b/src/futex_mutex.rs
@@ -8,8 +8,6 @@ use core::sync::atomic::{
 };
 use super::wait_wake::{futex_wait_timespec, futex_wake};
 
-pub type MovableMutex = Mutex;
-
 #[repr(transparent)]
 pub struct Mutex {
     /// 0: unlocked

--- a/src/futex_rwlock.rs
+++ b/src/futex_rwlock.rs
@@ -8,8 +8,6 @@ use core::sync::atomic::{
 };
 use super::wait_wake::{futex_wait_timespec, futex_wake, futex_wake_all};
 
-pub type MovableRwLock = RwLock;
-
 #[repr(C)]
 pub struct RwLock {
     // The state consists of a 30-bit reader counter, a 'readers waiting' flag, and a 'writers waiting' flag.

--- a/tests/repr.rs
+++ b/tests/repr.rs
@@ -1,5 +1,6 @@
-/// rustix_futex_sync documents some details of the representation of some of
-/// its public types.
+//! rustix_futex_sync documents some details of the representation of some of
+//! its public types.
+
 use core::mem::{align_of, size_of, transmute};
 use rustix_futex_sync::lock_api::{RawMutex as _, RawRwLock as _};
 use rustix_futex_sync::{Condvar, Once, RawCondvar, RawMutex, RawRwLock};


### PR DESCRIPTION
Tidy up some documentation, and add `#[inline]` to `RawMutex` and `RawRwLock`'s APIs.