### PR TITLE
Make the `lock_api` dependency optional.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,3 +121,7 @@ jobs:
         cargo test
       env:
         RUST_BACKTRACE: 1
+
+    - name: cargo check --no-default-features
+      run: |
+        cargo check --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.70"
 
 [dependencies]
 rustix = { version = "0.38.34", default-features = false, features = ["thread", "time"] }
-lock_api = { version = "0.4.7", default-features = false }
+lock_api = { version = "0.4.7", default-features = false, optional = true }
 
 # Special dependencies used in rustc-dep-of-std mode.
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
@@ -26,8 +26,9 @@ compiler_builtins = { version = "0.1.101", optional = true }
 rand = "0.8.5"
 
 [features]
-nightly = ["lock_api/nightly"]
-atomic_usize = ["lock_api/atomic_usize"]
+default = ["lock_api"]
+nightly = ["lock_api?/nightly"]
+atomic_usize = ["lock_api?/atomic_usize"]
 
 rustc-dep-of-std = [
     "dep:core",

--- a/src/futex_condvar.rs
+++ b/src/futex_condvar.rs
@@ -6,6 +6,7 @@ use core::sync::atomic::{AtomicU32, Ordering::Relaxed};
 use super::wait_wake::{futex_wait, futex_wake, futex_wake_all};
 use core::time::Duration;
 use super::RawMutex;
+use super::lock_api::RawMutex as _;
 
 #[repr(transparent)]
 pub struct Condvar {

--- a/src/futex_condvar.rs
+++ b/src/futex_condvar.rs
@@ -6,7 +6,6 @@ use core::sync::atomic::{AtomicU32, Ordering::Relaxed};
 use super::wait_wake::{futex_wait, futex_wake, futex_wake_all};
 use core::time::Duration;
 use super::RawMutex;
-use lock_api::RawMutex as _;
 
 #[repr(transparent)]
 pub struct Condvar {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,17 +3,25 @@
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 
 // Re-export this so that our users can use the same version we do.
+#[cfg(feature = "lock_api")]
 pub use lock_api;
 
 // Export convenient `Mutex` and `RwLock` types.
+#[cfg(feature = "lock_api")]
 pub type Mutex<T> = lock_api::Mutex<RawMutex, T>;
+#[cfg(feature = "lock_api")]
 pub type RwLock<T> = lock_api::RwLock<RawRwLock, T>;
+#[cfg(feature = "lock_api")]
 pub type MutexGuard<'a, T> = lock_api::MutexGuard<'a, RawMutex, T>;
+#[cfg(feature = "lock_api")]
 pub type RwLockReadGuard<'a, T> = lock_api::RwLockReadGuard<'a, RawRwLock, T>;
+#[cfg(feature = "lock_api")]
 pub type RwLockWriteGuard<'a, T> = lock_api::RwLockWriteGuard<'a, RawRwLock, T>;
+#[cfg(feature = "lock_api")]
 #[cfg(feature = "atomic_usize")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "atomic_usize")))]
 pub type ReentrantMutex<G, T> = lock_api::ReentrantMutex<RawMutex, G, T>;
+#[cfg(feature = "lock_api")]
 #[cfg(feature = "atomic_usize")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "atomic_usize")))]
 pub type ReentrantMutexGuard<'a, G, T> = lock_api::ReentrantMutexGuard<'a, RawMutex, G, T>;
@@ -23,12 +31,14 @@ pub use once::{Once, OnceState};
 pub use once_lock::OnceLock;
 
 // Export the condvar types.
+#[cfg(feature = "lock_api")]
 pub use condvar::{Condvar, WaitTimeoutResult};
 
 // Export the raw condvar types.
 pub type RawCondvar = futex_condvar::Condvar;
 
 // std's implementation code.
+#[cfg(feature = "lock_api")]
 mod condvar;
 mod futex_condvar;
 mod futex_mutex;
@@ -40,9 +50,8 @@ mod wait_wake;
 
 /// An implementation of [`lock_api::RawMutex`].
 ///
-/// All of this `RawMutex`'s methods are in its implementation of
-/// [`lock_api::RawMutex]`]. To import that trait without conflicting
-/// with this `RawMutex` type, use:
+/// To import [`lock_api::RawMutex`] without conflicting with this `RawMutex`
+/// type, use:
 ///
 /// ```
 /// use rustix_futex_sync::lock_api::RawMutex as _;
@@ -52,9 +61,8 @@ pub struct RawMutex(futex_mutex::Mutex);
 
 /// An implementation of [`lock_api::RawRwLock`].
 ///
-/// All of this `RawRwLock`'s methods are in its implementation of
-/// [`lock_api::RawRwLock]`]. To import that trait without conflicting
-/// with this `RawRwLock` type, use:
+/// To import [`lock_api::RawRwLock`] without conflicting with this `RawRwLock`
+/// type, use:
 ///
 /// ```
 /// use rustix_futex_sync::lock_api::RawRwLock as _;
@@ -64,59 +72,114 @@ pub struct RawRwLock(futex_rwlock::RwLock);
 
 // Implement the raw lock traits for our wrappers.
 
-unsafe impl lock_api::RawMutex for RawMutex {
-    type GuardMarker = lock_api::GuardNoSend;
-
-    const INIT: Self = Self(futex_mutex::Mutex::new());
+impl RawMutex {
+    pub const INIT: Self = Self(futex_mutex::Mutex::new());
 
     #[inline]
-    fn lock(&self) {
+    pub fn lock(&self) {
         self.0.lock()
     }
 
     #[inline]
-    fn try_lock(&self) -> bool {
+    pub fn try_lock(&self) -> bool {
         self.0.try_lock()
     }
 
     #[inline]
-    unsafe fn unlock(&self) {
+    pub unsafe fn unlock(&self) {
         self.0.unlock()
     }
 }
 
-unsafe impl lock_api::RawRwLock for RawRwLock {
+#[cfg(feature = "lock_api")]
+unsafe impl lock_api::RawMutex for RawMutex {
     type GuardMarker = lock_api::GuardNoSend;
 
-    const INIT: Self = Self(futex_rwlock::RwLock::new());
+    const INIT: Self = Self::INIT;
 
     #[inline]
-    fn lock_shared(&self) {
+    fn lock(&self) {
+        self.lock()
+    }
+
+    #[inline]
+    fn try_lock(&self) -> bool {
+        self.try_lock()
+    }
+
+    #[inline]
+    unsafe fn unlock(&self) {
+        self.unlock()
+    }
+}
+
+impl RawRwLock {
+    pub const INIT: Self = Self(futex_rwlock::RwLock::new());
+
+    #[inline]
+    pub fn lock_shared(&self) {
         self.0.read()
     }
 
     #[inline]
-    fn try_lock_shared(&self) -> bool {
+    pub fn try_lock_shared(&self) -> bool {
         self.0.try_read()
     }
 
     #[inline]
-    unsafe fn unlock_shared(&self) {
+    pub unsafe fn unlock_shared(&self) {
         self.0.read_unlock()
     }
 
     #[inline]
-    fn lock_exclusive(&self) {
+    pub fn lock_exclusive(&self) {
         self.0.write()
     }
 
     #[inline]
-    fn try_lock_exclusive(&self) -> bool {
+    pub fn try_lock_exclusive(&self) -> bool {
         self.0.try_write()
     }
 
     #[inline]
-    unsafe fn unlock_exclusive(&self) {
+    pub unsafe fn unlock_exclusive(&self) {
         self.0.write_unlock()
+    }
+}
+
+#[cfg(feature = "lock_api")]
+unsafe impl lock_api::RawRwLock for RawRwLock {
+    type GuardMarker = lock_api::GuardNoSend;
+
+    const INIT: Self = Self::INIT;
+
+    #[inline]
+    fn lock_shared(&self) {
+        self.lock_shared()
+    }
+
+    #[inline]
+    fn try_lock_shared(&self) -> bool {
+        self.try_lock_shared()
+    }
+
+    #[inline]
+    unsafe fn unlock_shared(&self) {
+        self.unlock_shared()
+    }
+
+    #[inline]
+    fn lock_exclusive(&self) {
+        self.lock_exclusive()
+    }
+
+    #[inline]
+    fn try_lock_exclusive(&self) -> bool {
+        self.try_lock_exclusive()
+    }
+
+    #[inline]
+    unsafe fn unlock_exclusive(&self) {
+        self.unlock_exclusive()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub use once_lock::OnceLock;
 pub use condvar::{Condvar, WaitTimeoutResult};
 
 // Export the raw condvar types.
-pub type RawCondvar = futex_condvar::Condvar;
+pub use futex_condvar::Condvar as RawCondvar;
 
 // std's implementation code.
 #[cfg(feature = "lock_api")]

--- a/src/lock_api.rs
+++ b/src/lock_api.rs
@@ -1,8 +1,14 @@
 //! Polyfills for `lock_api` traits for when we don't have the real `lock_api`
 //! crate.
 
+/// Polyfill for [`lock_api::GuardNoSend`].
+///
+/// [`lock_api::GuardNoSend`]: https://docs.rs/lock_api/*/lock_api/struct.GuardNoSend.html
 pub struct GuardNoSend(());
 
+/// Polyfill for [`lock_api::RawMutex`].
+///
+/// [`lock_api::RawMutex`]: https://docs.rs/lock_api/*/lock_api/trait.RawMutex.html
 pub unsafe trait RawMutex {
     type GuardMarker;
 
@@ -24,6 +30,9 @@ pub unsafe trait RawMutex {
     }
 }
 
+/// Polyfill for [`lock_api::RawRwLock`].
+///
+/// [`lock_api::RawRwLock`]: https://docs.rs/lock_api/*/lock_api/trait.RawRwLock.html
 pub unsafe trait RawRwLock {
     type GuardMarker;
 

--- a/src/lock_api.rs
+++ b/src/lock_api.rs
@@ -1,0 +1,59 @@
+//! Polyfills for `lock_api` traits for when we don't have the real `lock_api`
+//! crate.
+
+pub struct GuardNoSend(());
+
+pub unsafe trait RawMutex {
+    type GuardMarker;
+
+    const INIT: Self;
+
+    fn lock(&self);
+    fn try_lock(&self) -> bool;
+    unsafe fn unlock(&self);
+
+    #[inline]
+    fn is_locked(&self) -> bool {
+        let acquired_lock = self.try_lock();
+        if acquired_lock {
+            unsafe {
+                self.unlock();
+            }
+        }
+        !acquired_lock
+    }
+}
+
+pub unsafe trait RawRwLock {
+    type GuardMarker;
+
+    const INIT: Self;
+
+    fn lock_shared(&self);
+    fn try_lock_shared(&self) -> bool;
+    unsafe fn unlock_shared(&self);
+    fn lock_exclusive(&self);
+    fn try_lock_exclusive(&self) -> bool;
+    unsafe fn unlock_exclusive(&self);
+
+    #[inline]
+    fn is_locked(&self) -> bool {
+        let acquired_lock = self.try_lock_exclusive();
+        if acquired_lock {
+            unsafe {
+                self.unlock_exclusive();
+            }
+        }
+        !acquired_lock
+    }
+
+    fn is_locked_exclusive(&self) -> bool {
+        let acquired_lock = self.try_lock_shared();
+        if acquired_lock {
+            unsafe {
+                self.unlock_shared();
+            }
+        }
+        !acquired_lock
+    }
+}

--- a/tests/repr.rs
+++ b/tests/repr.rs
@@ -2,7 +2,6 @@
 //! its public types.
 
 use core::mem::{align_of, size_of, transmute};
-use rustix_futex_sync::lock_api::{RawMutex as _, RawRwLock as _};
 use rustix_futex_sync::{Condvar, Once, RawCondvar, RawMutex, RawRwLock};
 
 #[test]

--- a/tests/repr.rs
+++ b/tests/repr.rs
@@ -2,6 +2,7 @@
 //! its public types.
 
 use core::mem::{align_of, size_of, transmute};
+use rustix_futex_sync::lock_api::{RawMutex as _, RawRwLock as _};
 use rustix_futex_sync::{Condvar, Once, RawCondvar, RawMutex, RawRwLock};
 
 #[test]


### PR DESCRIPTION
Without `lock_api`, this crate only provides a small number of types such as `RawMutex` and `RawRwLock`, but if someone needs just those, it's reasonable to provide them without depending on `lock_api`.

This also makes `RawMutex` and `RawRwLock` easier to use, because it's no longer necessary to import the `lock_api` traits with the `as _` trick.