### PR TITLE
Add a shared-memory API.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,10 +118,10 @@ jobs:
 
     - name: cargo test
       run: |
-        cargo test
+        cargo test --features=atomic_usize,shm
       env:
         RUST_BACKTRACE: 1
 
     - name: cargo check --no-default-features
       run: |
-        cargo check --no-default-features
+        cargo check --no-default-features --features=atomic_usize,shm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rand = "0.8.5"
 default = ["lock_api"]
 nightly = ["lock_api?/nightly"]
 atomic_usize = ["lock_api?/atomic_usize"]
+shm = []
 
 rustc-dep-of-std = [
     "dep:core",
@@ -37,4 +38,4 @@ rustc-dep-of-std = [
 ]
 
 [package.metadata.docs.rs]
-features = ["atomic_usize"]
+features = ["atomic_usize", "shm"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ guaranteed to be a `repr(C)` wrapper around two `AtomicU32`s. The contents of
 these `AtomicU32`s are not documented, except that all these types'
 `const fn new()` and `INIT` are guaranteed to initialize them to all zeros.
 
+These types use the `FUTEX_PRIVATE_FLAG` flag so they don't work for
+synchronizing in memory shared between multiple processes. Enabling the "shm"
+feature enables the `shm` module, which contains shared-memory versions of all
+the main types.
+
 [`Mutex`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/type.Mutex.html
 [`RwLock`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/type.RwLock.html
 [`Condvar`]: https://docs.rs/rustix-futex-sync/latest/rustix_futex_sync/struct.Condvar.html

--- a/src/futex_mutex.rs
+++ b/src/futex_mutex.rs
@@ -12,7 +12,7 @@ type Atomic = atomic::AtomicU32;
 type State = u32;
 
 #[repr(transparent)]
-pub struct Mutex {
+pub struct Mutex<const SHM: bool> {
     futex: Atomic,
 }
 
@@ -20,7 +20,7 @@ const UNLOCKED: State = 0;
 const LOCKED: State = 1; // locked, no other threads waiting
 const CONTENDED: State = 2; // locked, and other threads waiting (contended)
 
-impl Mutex {
+impl<const SHM: bool> Mutex<SHM> {
     #[inline]
     pub const fn new() -> Self {
         Self { futex: Atomic::new(UNLOCKED) }
@@ -62,7 +62,7 @@ impl Mutex {
             }
 
             // Wait for the futex to change state, assuming it is still CONTENDED.
-            futex_wait_timespec(&self.futex, CONTENDED, None);
+            futex_wait_timespec::<SHM>(&self.futex, CONTENDED, None);
 
             // Spin again after waking up.
             state = self.spin();
@@ -100,6 +100,6 @@ impl Mutex {
 
     #[cold]
     fn wake(&self) {
-        futex_wake(&self.futex);
+        futex_wake::<SHM>(&self.futex);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,42 +10,136 @@ pub use lock_api;
 #[cfg(not(feature = "lock_api"))]
 pub mod lock_api;
 
-// Export convenient `Mutex` and `RwLock` types.
 #[cfg(feature = "lock_api")]
-pub type Mutex<T> = lock_api::Mutex<RawMutex, T>;
+pub use condvar::WaitTimeoutResult;
+pub use once::OnceState;
+
+// Non-shared API.
+
+pub type Once = generic::Once<false>;
 #[cfg(feature = "lock_api")]
-pub type RwLock<T> = lock_api::RwLock<RawRwLock, T>;
+pub type Condvar = generic::Condvar<false>;
+pub type RawCondvar = generic::RawCondvar<false>;
+pub type RawMutex = generic::RawMutex<false>;
+pub type RawRwLock = generic::RawRwLock<false>;
+pub type OnceLock<T> = generic::OnceLock<T, false>;
 #[cfg(feature = "lock_api")]
-pub type MutexGuard<'a, T> = lock_api::MutexGuard<'a, RawMutex, T>;
+pub type Mutex<T> = generic::Mutex<T, false>;
 #[cfg(feature = "lock_api")]
-pub type MappedMutexGuard<'a, T> = lock_api::MappedMutexGuard<'a, RawMutex, T>;
+pub type RwLock<T> = generic::RwLock<T, false>;
 #[cfg(feature = "lock_api")]
-pub type RwLockReadGuard<'a, T> = lock_api::RwLockReadGuard<'a, RawRwLock, T>;
+pub type MutexGuard<'a, T> = generic::MutexGuard<'a, T, false>;
 #[cfg(feature = "lock_api")]
-pub type RwLockWriteGuard<'a, T> = lock_api::RwLockWriteGuard<'a, RawRwLock, T>;
+pub type MappedMutexGuard<'a, T> = generic::MappedMutexGuard<'a, T, false>;
 #[cfg(feature = "lock_api")]
-pub type MappedRwLockReadGuard<'a, T> = lock_api::MappedRwLockReadGuard<'a, RawRwLock, T>;
+pub type RwLockReadGuard<'a, T> = generic::RwLockReadGuard<'a, T, false>;
 #[cfg(feature = "lock_api")]
-pub type MappedRwLockWriteGuard<'a, T> = lock_api::MappedRwLockWriteGuard<'a, RawRwLock, T>;
+pub type RwLockWriteGuard<'a, T> = generic::RwLockWriteGuard<'a, T, false>;
+#[cfg(feature = "lock_api")]
+pub type MappedRwLockReadGuard<'a, T> = generic::MappedRwLockReadGuard<'a, T, false>;
+#[cfg(feature = "lock_api")]
+pub type MappedRwLockWriteGuard<'a, T> = generic::MappedRwLockWriteGuard<'a, T, false>;
 #[cfg(feature = "lock_api")]
 #[cfg(feature = "atomic_usize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "atomic_usize")))]
-pub type ReentrantMutex<G, T> = lock_api::ReentrantMutex<RawMutex, G, T>;
+pub type ReentrantMutex<G, T> = generic::ReentrantMutex<G, T, false>;
 #[cfg(feature = "lock_api")]
 #[cfg(feature = "atomic_usize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "atomic_usize")))]
-pub type ReentrantMutexGuard<'a, G, T> = lock_api::ReentrantMutexGuard<'a, RawMutex, G, T>;
+pub type ReentrantMutexGuard<'a, G, T> = generic::ReentrantMutexGuard<'a, G, T, false>;
 
-// Export the once types.
-pub use once::{Once, OnceState};
-pub use once_lock::OnceLock;
+/// Shared-memory API.
+///
+/// The types in this module behave the same as the types defined at the top
+/// level of this crate, except that they don't set the `FUTEX_PRIVATE_FLAG`
+/// flag, so they can be used on memory shared with other processes.
+///
+/// See [the Linux documentation] for more information about
+/// `FUTEX_PRIVATE_FLAG`.
+///
+/// [the Linux documentation]: https://man7.org/linux/man-pages/man2/futex.2.html
+#[cfg(feature = "shm")]
+#[cfg_attr(docsrs, doc(cfg(feature = "shm")))]
+pub mod shm {
+    use crate::generic;
 
-// Export the condvar types.
-#[cfg(feature = "lock_api")]
-pub use condvar::{Condvar, WaitTimeoutResult};
+    pub type Once = generic::Once<true>;
+    #[cfg(feature = "lock_api")]
+    pub type Condvar = generic::Condvar<true>;
+    pub type RawCondvar = generic::RawCondvar<true>;
+    pub type RawMutex = generic::RawMutex<true>;
+    pub type RawRwLock = generic::RawRwLock<true>;
+    pub type OnceLock<T> = generic::OnceLock<T, true>;
+    #[cfg(feature = "lock_api")]
+    pub type Mutex<T> = generic::Mutex<T, true>;
+    #[cfg(feature = "lock_api")]
+    pub type RwLock<T> = generic::RwLock<T, true>;
+    #[cfg(feature = "lock_api")]
+    pub type MutexGuard<'a, T> = generic::MutexGuard<'a, T, true>;
+    #[cfg(feature = "lock_api")]
+    pub type MappedMutexGuard<'a, T> = generic::MappedMutexGuard<'a, T, true>;
+    #[cfg(feature = "lock_api")]
+    pub type RwLockReadGuard<'a, T> = generic::RwLockReadGuard<'a, T, true>;
+    #[cfg(feature = "lock_api")]
+    pub type RwLockWriteGuard<'a, T> = generic::RwLockWriteGuard<'a, T, true>;
+    #[cfg(feature = "lock_api")]
+    pub type MappedRwLockReadGuard<'a, T> = generic::MappedRwLockReadGuard<'a, T, true>;
+    #[cfg(feature = "lock_api")]
+    pub type MappedRwLockWriteGuard<'a, T> = generic::MappedRwLockWriteGuard<'a, T, true>;
+    #[cfg(feature = "lock_api")]
+    #[cfg(feature = "atomic_usize")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "atomic_usize")))]
+    pub type ReentrantMutex<G, T> = generic::ReentrantMutex<G, T, true>;
+    #[cfg(feature = "lock_api")]
+    #[cfg(feature = "atomic_usize")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "atomic_usize")))]
+    pub type ReentrantMutexGuard<'a, G, T> = generic::ReentrantMutexGuard<'a, G, T, true>;
+}
 
-// Export the raw condvar types.
-pub use futex_condvar::Condvar as RawCondvar;
+/// Types and traits with a `const SHM: bool>` generic paramters.
+///
+/// These are the generic types that are parameterized on whether they support
+/// shared memory or not. They are aliased as non-parameterized types in the
+/// top-level crate and in the `shm` module for better ergonomics.
+pub mod generic {
+    pub use crate::condvar::Condvar;
+    pub use crate::futex_condvar::Condvar as RawCondvar;
+    pub use crate::once::Once;
+    pub use crate::once_lock::OnceLock;
+    pub use crate::raw_mutex::RawMutex;
+    pub use crate::raw_rwlock::RawRwLock;
+
+    #[cfg(feature = "lock_api")]
+    pub type Mutex<T, const SHM: bool> = lock_api::Mutex<RawMutex<SHM>, T>;
+    #[cfg(feature = "lock_api")]
+    pub type RwLock<T, const SHM: bool> = lock_api::RwLock<RawRwLock<SHM>, T>;
+    #[cfg(feature = "lock_api")]
+    pub type MutexGuard<'a, T, const SHM: bool> = lock_api::MutexGuard<'a, RawMutex<SHM>, T>;
+    #[cfg(feature = "lock_api")]
+    pub type MappedMutexGuard<'a, T, const SHM: bool> =
+        lock_api::MappedMutexGuard<'a, RawMutex<SHM>, T>;
+    #[cfg(feature = "lock_api")]
+    pub type RwLockReadGuard<'a, T, const SHM: bool> =
+        lock_api::RwLockReadGuard<'a, RawRwLock<SHM>, T>;
+    #[cfg(feature = "lock_api")]
+    pub type RwLockWriteGuard<'a, T, const SHM: bool> =
+        lock_api::RwLockWriteGuard<'a, RawRwLock<SHM>, T>;
+    #[cfg(feature = "lock_api")]
+    pub type MappedRwLockReadGuard<'a, T, const SHM: bool> =
+        lock_api::MappedRwLockReadGuard<'a, RawRwLock<SHM>, T>;
+    #[cfg(feature = "lock_api")]
+    pub type MappedRwLockWriteGuard<'a, T, const SHM: bool> =
+        lock_api::MappedRwLockWriteGuard<'a, RawRwLock<SHM>, T>;
+    #[cfg(feature = "lock_api")]
+    #[cfg(feature = "atomic_usize")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "atomic_usize")))]
+    pub type ReentrantMutex<G, T, const SHM: bool> = lock_api::ReentrantMutex<RawMutex<SHM>, G, T>;
+    #[cfg(feature = "lock_api")]
+    #[cfg(feature = "atomic_usize")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "atomic_usize")))]
+    pub type ReentrantMutexGuard<'a, G, T, const SHM: bool> =
+        lock_api::ReentrantMutexGuard<'a, RawMutex<SHM>, G, T>;
+}
 
 // std's implementation code.
 #[cfg(feature = "lock_api")]
@@ -56,87 +150,6 @@ mod futex_once;
 mod futex_rwlock;
 mod once;
 mod once_lock;
+mod raw_mutex;
+mod raw_rwlock;
 mod wait_wake;
-
-/// An implementation of [`lock_api::RawMutex`].
-///
-/// All of this `RawMutex`'s methods are in its implementation of
-/// [`lock_api::RawMutex`]. To import that trait without conflicting
-/// with this `RawMutex` type, use:
-///
-/// ```
-/// use rustix_futex_sync::lock_api::RawMutex as _;
-/// ```
-#[repr(transparent)]
-pub struct RawMutex(futex_mutex::Mutex);
-
-/// An implementation of [`lock_api::RawRwLock`].
-///
-/// All of this `RawRwLock`'s methods are in its implementation of
-/// [`lock_api::RawRwLock`]. To import that trait without conflicting
-/// with this `RawRwLock` type, use:
-///
-/// ```
-/// use rustix_futex_sync::lock_api::RawRwLock as _;
-/// ```
-#[repr(C)]
-pub struct RawRwLock(futex_rwlock::RwLock);
-
-// Implement the raw lock traits for our wrappers.
-
-unsafe impl lock_api::RawMutex for RawMutex {
-    type GuardMarker = lock_api::GuardNoSend;
-
-    const INIT: Self = Self(futex_mutex::Mutex::new());
-
-    #[inline]
-    fn lock(&self) {
-        self.0.lock()
-    }
-
-    #[inline]
-    fn try_lock(&self) -> bool {
-        self.0.try_lock()
-    }
-
-    #[inline]
-    unsafe fn unlock(&self) {
-        self.0.unlock()
-    }
-}
-
-unsafe impl lock_api::RawRwLock for RawRwLock {
-    type GuardMarker = lock_api::GuardNoSend;
-
-    const INIT: Self = Self(futex_rwlock::RwLock::new());
-
-    #[inline]
-    fn lock_shared(&self) {
-        self.0.read()
-    }
-
-    #[inline]
-    fn try_lock_shared(&self) -> bool {
-        self.0.try_read()
-    }
-
-    #[inline]
-    unsafe fn unlock_shared(&self) {
-        self.0.read_unlock()
-    }
-
-    #[inline]
-    fn lock_exclusive(&self) {
-        self.0.write()
-    }
-
-    #[inline]
-    fn try_lock_exclusive(&self) -> bool {
-        self.0.try_write()
-    }
-
-    #[inline]
-    unsafe fn unlock_exclusive(&self) {
-        self.0.write_unlock()
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ pub mod shm {
 /// shared memory or not. They are aliased as non-parameterized types in the
 /// top-level crate and in the `shm` module for better ergonomics.
 pub mod generic {
+    #[cfg(feature = "lock_api")]
     pub use crate::condvar::Condvar;
     pub use crate::futex_condvar::Condvar as RawCondvar;
     pub use crate::once::Once;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@ pub type ReentrantMutexGuard<'a, G, T> = generic::ReentrantMutexGuard<'a, G, T, 
 pub mod shm {
     use crate::generic;
 
+    pub use super::lock_api;
+
     pub type Once = generic::Once<true>;
     #[cfg(feature = "lock_api")]
     pub type Condvar = generic::Condvar<true>;

--- a/src/once.rs
+++ b/src/once.rs
@@ -33,15 +33,15 @@ use super::futex_once as sys;
 /// ```
 //#[stable(feature = "rust1", since = "1.0.0")]
 #[repr(transparent)]
-pub struct Once {
-    inner: sys::Once,
+pub struct Once<const SHM: bool> {
+    inner: sys::Once<SHM>,
 }
 
 //#[stable(feature = "sync_once_unwind_safe", since = "1.59.0")]
-impl UnwindSafe for Once {}
+impl<const SHM: bool> UnwindSafe for Once<SHM> {}
 
 //#[stable(feature = "sync_once_unwind_safe", since = "1.59.0")]
-impl RefUnwindSafe for Once {}
+impl<const SHM: bool> RefUnwindSafe for Once<SHM> {}
 
 /// State yielded to [`Once::call_once_force()`]’s closure parameter. The state
 /// can be used to query the poison status of the [`Once`].
@@ -77,13 +77,13 @@ pub(crate) enum ExclusiveState {
 pub const ONCE_INIT: Once = Once::new();
 */
 
-impl Once {
+impl<const SHM: bool> Once<SHM> {
     /// Creates a new `Once` value.
     #[inline]
     //#[stable(feature = "once_new", since = "1.2.0")]
     //#[rustc_const_stable(feature = "const_once_new", since = "1.32.0")]
     #[must_use]
-    pub const fn new() -> Once {
+    pub const fn new() -> Self {
         Once { inner: sys::Once::new() }
     }
 
@@ -282,7 +282,7 @@ impl Once {
 }
 
 //#[stable(feature = "std_debug", since = "1.16.0")]
-impl fmt::Debug for Once {
+impl<const SHM: bool> fmt::Debug for Once<SHM> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Once").finish_non_exhaustive()
     }

--- a/src/raw_mutex.rs
+++ b/src/raw_mutex.rs
@@ -1,0 +1,32 @@
+/// An implementation of [`lock_api::RawMutex`].
+///
+/// All of this `RawMutex`'s methods are in its implementation of
+/// [`lock_api::RawMutex`]. To import that trait without conflicting
+/// with this `RawMutex` type, use:
+///
+/// ```
+/// use rustix_futex_sync::lock_api::RawMutex as _;
+/// ```
+#[repr(transparent)]
+pub struct RawMutex<const SHM: bool>(crate::futex_mutex::Mutex<SHM>);
+
+unsafe impl<const SHM: bool> lock_api::RawMutex for RawMutex<SHM> {
+    type GuardMarker = lock_api::GuardNoSend;
+
+    const INIT: Self = Self(crate::futex_mutex::Mutex::new());
+
+    #[inline]
+    fn lock(&self) {
+        self.0.lock()
+    }
+
+    #[inline]
+    fn try_lock(&self) -> bool {
+        self.0.try_lock()
+    }
+
+    #[inline]
+    unsafe fn unlock(&self) {
+        self.0.unlock()
+    }
+}

--- a/src/raw_mutex.rs
+++ b/src/raw_mutex.rs
@@ -1,3 +1,5 @@
+use crate::lock_api;
+
 /// An implementation of [`lock_api::RawMutex`].
 ///
 /// All of this `RawMutex`'s methods are in its implementation of

--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -1,3 +1,5 @@
+use crate::lock_api;
+
 /// An implementation of [`lock_api::RawRwLock`].
 ///
 /// All of this `RawRwLock`'s methods are in its implementation of

--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -1,0 +1,47 @@
+/// An implementation of [`lock_api::RawRwLock`].
+///
+/// All of this `RawRwLock`'s methods are in its implementation of
+/// [`lock_api::RawRwLock`]. To import that trait without conflicting
+/// with this `RawRwLock` type, use:
+///
+/// ```
+/// use rustix_futex_sync::lock_api::RawRwLock as _;
+/// ```
+#[repr(C)]
+pub struct RawRwLock<const SHM: bool>(crate::futex_rwlock::RwLock<SHM>);
+
+unsafe impl<const SHM: bool> lock_api::RawRwLock for RawRwLock<SHM> {
+    type GuardMarker = lock_api::GuardNoSend;
+
+    const INIT: Self = Self(crate::futex_rwlock::RwLock::new());
+
+    #[inline]
+    fn lock_shared(&self) {
+        self.0.read()
+    }
+
+    #[inline]
+    fn try_lock_shared(&self) -> bool {
+        self.0.try_read()
+    }
+
+    #[inline]
+    unsafe fn unlock_shared(&self) {
+        self.0.read_unlock()
+    }
+
+    #[inline]
+    fn lock_exclusive(&self) {
+        self.0.write()
+    }
+
+    #[inline]
+    fn try_lock_exclusive(&self) -> bool {
+        self.0.try_write()
+    }
+
+    #[inline]
+    unsafe fn unlock_exclusive(&self) {
+        self.0.write_unlock()
+    }
+}

--- a/tests/shm/basic.rs
+++ b/tests/shm/basic.rs
@@ -1,0 +1,70 @@
+#[test]
+fn mutex() {
+    use rustix_futex_sync::shm::Mutex;
+
+    let m = Mutex::new(0);
+    let mut locked = m.lock();
+    *locked = 1;
+    assert!(m.try_lock().is_none());
+    drop(locked);
+    let mut locked = m.try_lock().unwrap();
+    assert!(m.try_lock().is_none());
+    *locked = 2;
+    drop(locked);
+    let inner = m.into_inner();
+    assert_eq!(inner, 2);
+}
+
+#[test]
+fn rw_lock() {
+    use rustix_futex_sync::shm::RwLock;
+
+    let m = RwLock::new(0);
+    let locked = m.read();
+    assert_eq!(*locked, 0);
+    assert!(m.try_read().is_some());
+    assert!(m.try_write().is_none());
+    drop(locked);
+    let mut locked = m.write();
+    *locked = 1;
+    assert!(m.try_read().is_none());
+    assert!(m.try_write().is_none());
+    drop(locked);
+    let locked = m.try_read().unwrap();
+    assert_eq!(*locked, 1);
+    drop(locked);
+    let mut locked = m.try_write().unwrap();
+    *locked = 2;
+    drop(locked);
+    let locked = m.try_read().unwrap();
+    assert_eq!(*locked, 2);
+    drop(locked);
+    let inner = m.into_inner();
+    assert_eq!(inner, 2);
+}
+
+#[test]
+fn condvar() {
+    use rustix_futex_sync::shm::{Condvar, Mutex};
+    use std::sync::Arc;
+    use std::thread;
+
+    let pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let pair2 = pair.clone();
+
+    // Inside of our lock, spawn a new thread, and then wait for it to start
+    thread::spawn(move || {
+        let (lock, cvar) = &*pair2;
+        let mut started = lock.lock();
+        *started = true;
+        cvar.notify_one();
+    });
+
+    // wait for the thread to start up
+    let (lock, cvar) = &*pair;
+    let mut started = lock.lock();
+    if !*started {
+        started = cvar.wait(started);
+    }
+    drop(started);
+}

--- a/tests/shm/main.rs
+++ b/tests/shm/main.rs
@@ -1,0 +1,12 @@
+#![cfg(feature = "shm")]
+mod basic;
+mod mutex_examples;
+mod once_lock;
+mod once;
+mod parking_lot_issue_203;
+mod parking_lot_issue_392;
+mod repr;
+mod rwlock_examples;
+mod sync_condvar;
+mod sync_mutex;
+mod sync_rwlock;

--- a/tests/shm/mutex_examples.rs
+++ b/tests/shm/mutex_examples.rs
@@ -1,0 +1,178 @@
+//! The following is derived from the documentation tests in Rust's
+//! library/std/src/sync/mutex.rs at revision
+//! e853b50a722c09c7526683316b5471528063cccd.
+
+#[test]
+fn mutex_example_0() {
+    use std::sync::Arc;
+    use rustix_futex_sync::shm::Mutex;
+    use std::thread;
+    use std::sync::mpsc::channel;
+
+    const N: usize = 10;
+
+    // Spawn a few threads to increment a shared variable (non-atomically), and
+    // let the main thread know once all increments are done.
+    //
+    // Here we're using an Arc to share memory among threads, and the data inside
+    // the Arc is protected with a mutex.
+    let data = Arc::new(Mutex::new(0));
+
+    let (tx, rx) = channel();
+    for _ in 0..N {
+        let (data, tx) = (Arc::clone(&data), tx.clone());
+        thread::spawn(move || {
+            // The shared state can only be accessed once the lock is held.
+            // Our non-atomic increment is safe because we're the only thread
+            // which can access the shared state when the lock is held.
+            //
+            // We unwrap() the return value to assert that we are not expecting
+            // threads to ever fail while holding the lock.
+            let mut data = data.lock();
+            *data += 1;
+            if *data == N {
+                tx.send(()).unwrap();
+            }
+            // the lock is unlocked here when `data` goes out of scope.
+        });
+    }
+
+    rx.recv().unwrap();
+}
+
+#[test]
+fn mutex_example_1() {
+    use std::sync::Arc;
+    use rustix_futex_sync::shm::Mutex;
+    use std::thread;
+
+    const N: usize = 3;
+
+    let data_mutex = Arc::new(Mutex::new(vec![1, 2, 3, 4]));
+    let res_mutex = Arc::new(Mutex::new(0));
+
+    let mut threads = Vec::with_capacity(N);
+    (0..N).for_each(|_| {
+        let data_mutex_clone = Arc::clone(&data_mutex);
+        let res_mutex_clone = Arc::clone(&res_mutex);
+
+        threads.push(thread::spawn(move || {
+            // Here we use a block to limit the lifetime of the lock guard.
+            let result = {
+                let mut data = data_mutex_clone.lock();
+                // This is the result of some important and long-ish work.
+                let result = data.iter().fold(0, |acc, x| acc + x * 2);
+                data.push(result);
+                result
+                // The mutex guard gets dropped here, together with any other values
+                // created in the critical section.
+            };
+            // The guard created here is a temporary dropped at the end of the statement, i.e.
+            // the lock would not remain being held even if the thread did some additional work.
+            *res_mutex_clone.lock() += result;
+        }));
+    });
+
+    let mut data = data_mutex.lock();
+    // This is the result of some important and long-ish work.
+    let result = data.iter().fold(0, |acc, x| acc + x * 2);
+    data.push(result);
+    // We drop the `data` explicitly because it's not necessary anymore and the
+    // thread still has work to do. This allow other threads to start working on
+    // the data immediately, without waiting for the rest of the unrelated work
+    // to be done here.
+    //
+    // It's even more important here than in the threads because we `.join` the
+    // threads after that. If we had not dropped the mutex guard, a thread could
+    // be waiting forever for it, causing a deadlock.
+    // As in the threads, a block could have been used instead of calling the
+    // `drop` function.
+    drop(data);
+    // Here the mutex guard is not assigned to a variable and so, even if the
+    // scope does not end after this line, the mutex is still released: there is
+    // no deadlock.
+    *res_mutex.lock() += result;
+
+    threads.into_iter().for_each(|thread| {
+        thread
+            .join()
+            .expect("The thread creating or execution failed !")
+    });
+
+    assert_eq!(*res_mutex.lock(), 800);
+}
+
+#[test]
+fn mutex_example_2() {
+    use rustix_futex_sync::shm::Mutex;
+
+    let _mutex = Mutex::new(0);
+}
+
+#[test]
+fn mutex_example_3() {
+    use std::sync::Arc;
+    use rustix_futex_sync::shm::Mutex;
+    use std::thread;
+
+    let mutex = Arc::new(Mutex::new(0));
+    let c_mutex = Arc::clone(&mutex);
+
+    thread::spawn(move || {
+        *c_mutex.lock() = 10;
+    }).join().expect("thread::spawn failed");
+    assert_eq!(*mutex.lock(), 10);
+}
+
+#[test]
+fn mutex_example_4() {
+    use std::sync::Arc;
+    use rustix_futex_sync::shm::Mutex;
+    use std::thread;
+
+    let mutex = Arc::new(Mutex::new(0));
+    let c_mutex = Arc::clone(&mutex);
+
+    thread::spawn(move || {
+        let mut lock = c_mutex.try_lock();
+        if let Some(ref mut mutex) = lock {
+            **mutex = 10;
+        } else {
+            println!("try_lock failed");
+        }
+    }).join().expect("thread::spawn failed");
+    assert_eq!(*mutex.lock(), 10);
+}
+
+#[test]
+fn mutex_example_5() {
+    use std::sync::Arc;
+    use rustix_futex_sync::shm::Mutex;
+    use std::thread;
+
+    let mutex = Arc::new(Mutex::new(0));
+    let c_mutex = Arc::clone(&mutex);
+
+    let _ = thread::spawn(move || {
+        let _lock = c_mutex.lock();
+        panic!(); // the mutex gets poisoned
+    }).join();
+    //assert_eq!(mutex.is_poisoned(), true);
+}
+
+#[test]
+fn mutex_example_6() {
+    use rustix_futex_sync::shm::Mutex;
+
+    let mutex = Mutex::new(0);
+    assert_eq!(mutex.into_inner(), 0);
+}
+
+#[test]
+fn mutex_example_7() {
+    use rustix_futex_sync::shm::Mutex;
+
+    let mut mutex = Mutex::new(0);
+    *mutex.get_mut() = 10;
+    assert_eq!(*mutex.lock(), 10);
+}

--- a/tests/shm/once.rs
+++ b/tests/shm/once.rs
@@ -1,0 +1,125 @@
+//! The following is derived from Rust's
+//! library/std/src/sync/once/tests.rs at revision
+//! f42e96149dd03e816b8bc3c329e7b9a5d12fcdab.
+
+use rustix_futex_sync::shm::Once;
+use std::panic;
+use std::sync::mpsc::channel;
+use std::thread;
+
+#[test]
+fn smoke_once() {
+    static O: Once = Once::new();
+    let mut a = 0;
+    O.call_once(|| a += 1);
+    assert_eq!(a, 1);
+    O.call_once(|| a += 1);
+    assert_eq!(a, 1);
+}
+
+#[test]
+fn stampede_once() {
+    static O: Once = Once::new();
+    static mut RUN: bool = false;
+
+    let (tx, rx) = channel();
+    for _ in 0..10 {
+        let tx = tx.clone();
+        thread::spawn(move || {
+            for _ in 0..4 {
+                thread::yield_now()
+            }
+            unsafe {
+                O.call_once(|| {
+                    assert!(!RUN);
+                    RUN = true;
+                });
+                assert!(RUN);
+            }
+            tx.send(()).unwrap();
+        });
+    }
+
+    unsafe {
+        O.call_once(|| {
+            assert!(!RUN);
+            RUN = true;
+        });
+        assert!(RUN);
+    }
+
+    for _ in 0..10 {
+        rx.recv().unwrap();
+    }
+}
+
+#[test]
+fn poison_bad() {
+    static O: Once = Once::new();
+
+    // poison the once
+    let t = panic::catch_unwind(|| {
+        O.call_once(|| panic!());
+    });
+    assert!(t.is_err());
+
+    /*
+    // poisoning propagates
+    let t = panic::catch_unwind(|| {
+        O.call_once(|| {});
+    });
+    //assert!(t.is_err());
+    let _ = t;
+    */
+
+    // we can subvert poisoning, however
+    let mut called = false;
+    O.call_once_force(|p| {
+        called = true;
+        //assert!(p.is_poisoned())
+        let _ = p;
+    });
+    assert!(called);
+
+    // once any success happens, we stop propagating the poison
+    O.call_once(|| {});
+}
+
+#[test]
+fn wait_for_force_to_finish() {
+    static O: Once = Once::new();
+
+    // poison the once
+    let t = panic::catch_unwind(|| {
+        O.call_once(|| panic!());
+    });
+    assert!(t.is_err());
+
+    // make sure someone's waiting inside the once via a force
+    let (tx1, rx1) = channel();
+    let (tx2, rx2) = channel();
+    let t1 = thread::spawn(move || {
+        O.call_once_force(|p| {
+            //assert!(p.is_poisoned());
+            let _ = p;
+            tx1.send(()).unwrap();
+            rx2.recv().unwrap();
+        });
+    });
+
+    rx1.recv().unwrap();
+
+    // put another waiter on the once
+    let t2 = thread::spawn(|| {
+        let mut called = false;
+        O.call_once(|| {
+            called = true;
+        });
+        assert!(!called);
+    });
+
+    tx2.send(()).unwrap();
+
+    assert!(t1.join().is_ok());
+    assert!(t2.join().is_ok());
+}

--- a/tests/shm/once_lock.rs
+++ b/tests/shm/once_lock.rs
@@ -1,0 +1,210 @@
+//! The following is derived from Rust's
+//! library/std/src/sync/once_lock/tests.rs at revision
+//! 9cb934600533f6bee22b7396d1ff013b381322a8.
+
+use rustix_futex_sync::shm::OnceLock;
+use std::{
+    panic,
+    sync::{
+        atomic::{AtomicUsize, Ordering::SeqCst},
+        mpsc::channel,
+    },
+    thread,
+};
+
+fn spawn_and_wait<R: Send + 'static>(f: impl FnOnce() -> R + Send + 'static) -> R {
+    thread::spawn(f).join().unwrap()
+}
+
+#[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
+fn sync_once_cell() {
+    static ONCE_CELL: OnceLock<i32> = OnceLock::new();
+
+    assert!(ONCE_CELL.get().is_none());
+
+    spawn_and_wait(|| {
+        ONCE_CELL.get_or_init(|| 92);
+        assert_eq!(ONCE_CELL.get(), Some(&92));
+    });
+
+    ONCE_CELL.get_or_init(|| panic!("Kaboom!"));
+    assert_eq!(ONCE_CELL.get(), Some(&92));
+}
+
+#[test]
+fn sync_once_cell_get_mut() {
+    let mut c = OnceLock::new();
+    assert!(c.get_mut().is_none());
+    c.set(90).unwrap();
+    *c.get_mut().unwrap() += 2;
+    assert_eq!(c.get_mut(), Some(&mut 92));
+}
+
+#[test]
+fn sync_once_cell_get_unchecked() {
+    let c = OnceLock::new();
+    c.set(92).unwrap();
+    //unsafe {
+    //    assert_eq!(c.get_unchecked(), &92); // private API
+    //}
+}
+
+#[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
+fn sync_once_cell_drop() {
+    static DROP_CNT: AtomicUsize = AtomicUsize::new(0);
+    struct Dropper;
+    impl Drop for Dropper {
+        fn drop(&mut self) {
+            DROP_CNT.fetch_add(1, SeqCst);
+        }
+    }
+
+    let x = OnceLock::new();
+    spawn_and_wait(move || {
+        x.get_or_init(|| Dropper);
+        assert_eq!(DROP_CNT.load(SeqCst), 0);
+        drop(x);
+    });
+
+    assert_eq!(DROP_CNT.load(SeqCst), 1);
+}
+
+#[test]
+fn sync_once_cell_drop_empty() {
+    let x = OnceLock::<String>::new();
+    drop(x);
+}
+
+#[test]
+fn clone() {
+    let s = OnceLock::new();
+    let c = s.clone();
+    assert!(c.get().is_none());
+
+    s.set("hello".to_string()).unwrap();
+    let c = s.clone();
+    assert_eq!(c.get().map(String::as_str), Some("hello"));
+}
+
+#[test]
+fn get_or_try_init() {
+    let cell: OnceLock<String> = OnceLock::new();
+    assert!(cell.get().is_none());
+
+    let res = panic::catch_unwind(|| cell.get_or_try_init(|| -> Result<_, ()> { panic!() }));
+    assert!(res.is_err());
+    //assert!(!cell.is_initialized()); // private API
+    assert!(cell.get().is_none());
+
+    assert_eq!(cell.get_or_try_init(|| Err(())), Err(()));
+    assert!(cell.get().is_none());
+
+    assert_eq!(cell.get_or_try_init(|| Ok::<_, ()>("hello".to_string())), Ok(&"hello".to_string()));
+    assert_eq!(cell.get(), Some(&"hello".to_string()));
+}
+
+#[test]
+fn from_impl() {
+    assert_eq!(OnceLock::from("value").get(), Some(&"value"));
+    assert_ne!(OnceLock::from("foo").get(), Some(&"bar"));
+}
+
+#[test]
+fn partialeq_impl() {
+    assert!(OnceLock::from("value") == OnceLock::from("value"));
+    assert!(OnceLock::from("foo") != OnceLock::from("bar"));
+
+    assert!(OnceLock::<String>::new() == OnceLock::new());
+    assert!(OnceLock::<String>::new() != OnceLock::from("value".to_owned()));
+}
+
+#[test]
+fn into_inner() {
+    let cell: OnceLock<String> = OnceLock::new();
+    assert_eq!(cell.into_inner(), None);
+    let cell = OnceLock::new();
+    cell.set("hello".to_string()).unwrap();
+    assert_eq!(cell.into_inner(), Some("hello".to_string()));
+}
+
+#[test]
+fn is_sync_send() {
+    fn assert_traits<T: Send + Sync>() {}
+    assert_traits::<OnceLock<String>>();
+}
+
+#[test]
+fn eval_once_macro() {
+    macro_rules! eval_once {
+        (|| -> $ty:ty {
+            $($body:tt)*
+        }) => {{
+            static ONCE_CELL: OnceLock<$ty> = OnceLock::new();
+            fn init() -> $ty {
+                $($body)*
+            }
+            ONCE_CELL.get_or_init(init)
+        }};
+    }
+
+    let fib: &'static Vec<i32> = eval_once! {
+        || -> Vec<i32> {
+            let mut res = vec![1, 1];
+            for i in 0..10 {
+                let next = res[i] + res[i + 1];
+                res.push(next);
+            }
+            res
+        }
+    };
+    assert_eq!(fib[5], 8)
+}
+
+#[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
+fn sync_once_cell_does_not_leak_partially_constructed_boxes() {
+    static ONCE_CELL: OnceLock<String> = OnceLock::new();
+
+    let n_readers = 10;
+    let n_writers = 3;
+    const MSG: &str = "Hello, World";
+
+    let (tx, rx) = channel();
+
+    for _ in 0..n_readers {
+        let tx = tx.clone();
+        thread::spawn(move || {
+            loop {
+                if let Some(msg) = ONCE_CELL.get() {
+                    tx.send(msg).unwrap();
+                    break;
+                }
+                #[cfg(target_env = "sgx")]
+                std::thread::yield_now();
+            }
+        });
+    }
+    for _ in 0..n_writers {
+        thread::spawn(move || {
+            let _ = ONCE_CELL.set(MSG.to_owned());
+        });
+    }
+
+    for _ in 0..n_readers {
+        let msg = rx.recv().unwrap();
+        assert_eq!(msg, MSG);
+    }
+}
+
+/* // needs `impl<#[may_dangle] T> Drop` syntax
+#[test]
+fn dropck() {
+    let cell = OnceLock::new();
+    {
+        let s = String::new();
+        cell.set(&s).unwrap();
+    }
+}
+*/

--- a/tests/shm/parking_lot_issue_203.rs
+++ b/tests/shm/parking_lot_issue_203.rs
@@ -1,0 +1,30 @@
+//! This test is derived from `parking_lot` at
+//! <https://github.com/Amanieu/parking_lot/blob/master/tests/issue_203.rs>
+//! at revision 699325c9a7119694f009372c7a4f83c8fa8384a6.
+
+use rustix_futex_sync::shm::RwLock;
+use std::thread;
+
+struct Bar(RwLock<()>);
+
+impl Drop for Bar {
+    fn drop(&mut self) {
+        let _n = self.0.write();
+    }
+}
+
+thread_local! {
+    static B: Bar = Bar(RwLock::new(()));
+}
+
+#[test]
+fn main() {
+    thread::spawn(|| {
+        B.with(|_| ());
+
+        let a = RwLock::new(());
+        let _a = a.read();
+    })
+    .join()
+    .unwrap();
+}

--- a/tests/shm/parking_lot_issue_392.rs
+++ b/tests/shm/parking_lot_issue_392.rs
@@ -1,0 +1,22 @@
+//! This test is derived from `parking_lot` at
+//! <https://github.com/Amanieu/parking_lot/blob/master/tests/issue_392.rs>
+//! at revision 64b711461ed528de7c05868e5024f21e602cd4e0.
+
+// rustix_futex_sync doesn't currently support upgrading
+/*
+use rustix_futex_sync::shm::RwLock;
+
+struct Lock(RwLock<i32>);
+
+#[test]
+fn issue_392() {
+    let lock = Lock(RwLock::new(0));
+    let mut rl = lock.0.upgradable_read();
+    rl.with_upgraded(|_| {
+        println!("lock upgrade");
+    });
+    rl.with_upgraded(|_| {
+        println!("lock upgrade");
+    });
+}
+*/

--- a/tests/shm/repr.rs
+++ b/tests/shm/repr.rs
@@ -1,0 +1,65 @@
+//! rustix_futex_sync documents some details of the representation of some of
+//! its public types.
+
+use core::mem::{align_of, size_of, transmute};
+use rustix_futex_sync::shm::lock_api::{RawMutex as _, RawRwLock as _};
+use rustix_futex_sync::shm::{Condvar, Once, RawCondvar, RawMutex, RawRwLock};
+
+#[test]
+fn repr_raw_mutex() {
+    assert_eq!(size_of::<RawMutex>(), size_of::<u32>());
+    assert_eq!(align_of::<RawMutex>(), align_of::<u32>());
+    unsafe {
+        assert_eq!(transmute::<RawMutex, u32>(RawMutex::INIT), 0_u32);
+    }
+}
+
+#[test]
+fn repr_raw_condvar() {
+    assert_eq!(size_of::<RawCondvar>(), size_of::<u32>());
+    assert_eq!(align_of::<RawCondvar>(), align_of::<u32>());
+    unsafe {
+        assert_eq!(transmute::<RawCondvar, u32>(RawCondvar::new()), 0_u32);
+    }
+}
+
+#[test]
+fn repr_condvar() {
+    assert_eq!(size_of::<Condvar>(), size_of::<u32>());
+    assert_eq!(align_of::<Condvar>(), align_of::<u32>());
+    unsafe {
+        assert_eq!(transmute::<Condvar, u32>(Condvar::new()), 0_u32);
+    }
+}
+
+#[test]
+fn repr_once() {
+    assert_eq!(size_of::<Once>(), size_of::<u32>());
+    assert_eq!(align_of::<Once>(), align_of::<u32>());
+    unsafe {
+        assert_eq!(transmute::<Once, u32>(Once::new()), 0_u32);
+    }
+}
+
+#[test]
+fn repr_raw_rwlock() {
+    assert_eq!(size_of::<RawRwLock>(), size_of::<[u32; 2]>());
+    assert_eq!(align_of::<RawRwLock>(), align_of::<[u32; 2]>());
+    unsafe {
+        assert_eq!(
+            transmute::<RawRwLock, [u32; 2]>(RawRwLock::INIT),
+            [0_u32; 2]
+        );
+    }
+}
+
+// Test that the types are FFI-safe.
+#[allow(dead_code)]
+#[deny(improper_ctypes)]
+extern "C" {
+    fn use_raw_mutex(x: RawMutex);
+    fn use_raw_rwlock(x: RawRwLock);
+    fn use_condvar(x: Condvar);
+    fn use_raw_condvar(x: RawCondvar);
+    fn use_once(x: Once);
+}

--- a/tests/shm/rwlock_examples.rs
+++ b/tests/shm/rwlock_examples.rs
@@ -1,0 +1,122 @@
+//! The following is derived from the documentation tests in Rust's
+//! library/std/src/sync/rwlock.rs at revision
+//! 0cd57725f9d624aed3cdaa3852a1f80f550ae275.
+
+#[test]
+fn rwlock_example_0() {
+    use rustix_futex_sync::shm::RwLock;
+
+    let lock = RwLock::new(5);
+
+    // many reader locks can be held at once
+    {
+        let r1 = lock.read();
+        let r2 = lock.read();
+        assert_eq!(*r1, 5);
+        assert_eq!(*r2, 5);
+    } // read locks are dropped at this point
+
+    // only one write lock may be held, however
+    {
+        let mut w = lock.write();
+        *w += 1;
+        assert_eq!(*w, 6);
+    } // write lock is dropped here
+}
+
+#[test]
+fn rwlock_example_1() {
+    use rustix_futex_sync::shm::RwLock;
+
+    let _lock = RwLock::new(5);
+}
+
+#[test]
+fn rwlock_example_2() {
+    use std::sync::Arc;
+    use rustix_futex_sync::shm::RwLock;
+    use std::thread;
+
+    let lock = Arc::new(RwLock::new(1));
+    let c_lock = Arc::clone(&lock);
+
+    let n = lock.read();
+    assert_eq!(*n, 1);
+
+    thread::spawn(move || {
+        let _r = c_lock.read();
+    }).join().unwrap();
+}
+
+#[test]
+fn rwlock_example_3() {
+    use rustix_futex_sync::shm::RwLock;
+
+    let lock = RwLock::new(1);
+
+    match lock.try_read() {
+        Some(n) => assert_eq!(*n, 1),
+        None => unreachable!(),
+    };
+}
+
+#[test]
+fn rwlock_example_4() {
+    use rustix_futex_sync::shm::RwLock;
+
+    let lock = RwLock::new(1);
+
+    let mut n = lock.write();
+    *n = 2;
+
+    assert!(lock.try_read().is_none());
+}
+
+#[test]
+fn rwlock_example_5() {
+    use rustix_futex_sync::shm::RwLock;
+
+    let lock = RwLock::new(1);
+
+    let n = lock.read();
+    assert_eq!(*n, 1);
+
+    assert!(lock.try_write().is_none());
+}
+
+#[test]
+fn rwlock_example_6() {
+    use std::sync::Arc;
+    use rustix_futex_sync::shm::RwLock;
+    use std::thread;
+
+    let lock = Arc::new(RwLock::new(0));
+    let c_lock = Arc::clone(&lock);
+
+    let _ = thread::spawn(move || {
+    let _lock = c_lock.write();
+        panic!(); // the lock gets poisoned
+    }).join();
+    //assert_eq!(lock.is_poisoned(), true);
+}
+
+#[test]
+fn rwlock_example_7() {
+    use rustix_futex_sync::shm::RwLock;
+
+    let lock = RwLock::new(String::new());
+    {
+        let mut s = lock.write();
+        *s = "modified".to_owned();
+    }
+    assert_eq!(lock.into_inner(), "modified");
+}
+
+#[test]
+fn rwlock_example_8() {
+    use rustix_futex_sync::shm::RwLock;
+
+    let mut lock = RwLock::new(0);
+    *lock.get_mut() = 10;
+    assert_eq!(*lock.read(), 10);
+}

--- a/tests/shm/sync_condvar.rs
+++ b/tests/shm/sync_condvar.rs
@@ -1,0 +1,203 @@
+//! The following is derived from Rust's
+//! library/std/src/sync/condvar/tests.rs at revision
+//! 34621757ea9437994ef717ac4f1928933a6e1b24.
+
+use rustix_futex_sync::shm::{Condvar, Mutex};
+/*use std::sync::atomic::{AtomicBool, Ordering};*/
+use std::sync::mpsc::channel;
+use std::sync::Arc;
+use std::thread;
+/*use std::time::Duration;*/
+
+#[test]
+fn smoke() {
+    let c = Condvar::new();
+    c.notify_one();
+    c.notify_all();
+}
+
+#[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
+fn notify_one() {
+    let m = Arc::new(Mutex::new(()));
+    let m2 = m.clone();
+    let c = Arc::new(Condvar::new());
+    let c2 = c.clone();
+
+    let g = m.lock();
+    let _t = thread::spawn(move || {
+        let _g = m2.lock();
+        c2.notify_one();
+    });
+    let g = c.wait(g);
+    drop(g);
+}
+
+#[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
+fn notify_all() {
+    const N: usize = 10;
+
+    let data = Arc::new((Mutex::new(0), Condvar::new()));
+    let (tx, rx) = channel();
+    for _ in 0..N {
+        let data = data.clone();
+        let tx = tx.clone();
+        thread::spawn(move || {
+            let &(ref lock, ref cond) = &*data;
+            let mut cnt = lock.lock();
+            *cnt += 1;
+            if *cnt == N {
+                tx.send(()).unwrap();
+            }
+            while *cnt != 0 {
+                cnt = cond.wait(cnt);
+            }
+            tx.send(()).unwrap();
+        });
+    }
+    drop(tx);
+
+    let &(ref lock, ref cond) = &*data;
+    rx.recv().unwrap();
+    let mut cnt = lock.lock();
+    *cnt = 0;
+    cond.notify_all();
+    drop(cnt);
+
+    for _ in 0..N {
+        rx.recv().unwrap();
+    }
+}
+
+/*
+#[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
+fn wait_while() {
+    let pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let pair2 = pair.clone();
+
+    // Inside of our lock, spawn a new thread, and then wait for it to start.
+    thread::spawn(move || {
+        let &(ref lock, ref cvar) = &*pair2;
+        let mut started = lock.lock();
+        *started = true;
+        // We notify the condvar that the value has changed.
+        cvar.notify_one();
+    });
+
+    // Wait for the thread to start up.
+    let &(ref lock, ref cvar) = &*pair;
+    let guard = cvar.wait_while(lock.lock(), |started| !*started);
+    assert!(*guard.unwrap());
+}
+
+#[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
+fn wait_timeout_wait() {
+    let m = Arc::new(Mutex::new(()));
+    let c = Arc::new(Condvar::new());
+
+    loop {
+        let g = m.lock();
+        let (_g, no_timeout) = c.wait_timeout(g, Duration::from_millis(1));
+        // spurious wakeups mean this isn't necessarily true
+        // so execute test again, if not timeout
+        if !no_timeout.timed_out() {
+            continue;
+        }
+
+        break;
+    }
+}
+
+#[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
+fn wait_timeout_while_wait() {
+    let m = Arc::new(Mutex::new(()));
+    let c = Arc::new(Condvar::new());
+
+    let g = m.lock();
+    let (_g, wait) = c
+        .wait_timeout_while(g, Duration::from_millis(1), |_| true)
+        .unwrap();
+    // no spurious wakeups. ensure it timed-out
+    assert!(wait.timed_out());
+}
+
+#[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
+fn wait_timeout_while_instant_satisfy() {
+    let m = Arc::new(Mutex::new(()));
+    let c = Arc::new(Condvar::new());
+
+    let g = m.lock();
+    let (_g, wait) = c
+        .wait_timeout_while(g, Duration::from_millis(0), |_| false)
+        .unwrap();
+    // ensure it didn't time-out even if we were not given any time.
+    assert!(!wait.timed_out());
+}
+
+#[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
+fn wait_timeout_while_wake() {
+    let pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let pair_copy = pair.clone();
+
+    let &(ref m, ref c) = &*pair;
+    let g = m.lock();
+    let _t = thread::spawn(move || {
+        let &(ref lock, ref cvar) = &*pair_copy;
+        let mut started = lock.lock();
+        thread::sleep(Duration::from_millis(1));
+        *started = true;
+        cvar.notify_one();
+    });
+    let (g2, wait) = c
+        .wait_timeout_while(g, Duration::from_millis(u64::MAX), |&mut notified| {
+            !notified
+        })
+        .unwrap();
+    // ensure it didn't time-out even if we were not given any time.
+    assert!(!wait.timed_out());
+    assert!(*g2);
+}
+
+#[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
+fn wait_timeout_wake() {
+    let m = Arc::new(Mutex::new(()));
+    let c = Arc::new(Condvar::new());
+
+    loop {
+        let g = m.lock();
+
+        let c2 = c.clone();
+        let m2 = m.clone();
+
+        let notified = Arc::new(AtomicBool::new(false));
+        let notified_copy = notified.clone();
+
+        let t = thread::spawn(move || {
+            let _g = m2.lock();
+            thread::sleep(Duration::from_millis(1));
+            notified_copy.store(true, Ordering::Relaxed);
+            c2.notify_one();
+        });
+        let (g, timeout_res) = c.wait_timeout(g, Duration::from_millis(u64::MAX));
+        assert!(!timeout_res.timed_out());
+        // spurious wakeups mean this isn't necessarily true
+        // so execute test again, if not notified
+        if !notified.load(Ordering::Relaxed) {
+            t.join().unwrap();
+            continue;
+        }
+        drop(g);
+
+        t.join().unwrap();
+
+        break;
+    }
+}
+*/

--- a/tests/shm/sync_mutex.rs
+++ b/tests/shm/sync_mutex.rs
@@ -1,0 +1,347 @@
+//! The following is derived from Rust's
+//! library/std/src/sync/mutex/tests.rs at revision
+//! 3ef4b083ac03fd25339be009e3ae525adab30d78.
+
+use rustix_futex_sync::shm::Condvar;
+use rustix_futex_sync::shm::{Mutex, MutexGuard, MappedMutexGuard};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc::channel;
+use std::sync::Arc;
+use std::thread;
+
+struct Packet<T>(Arc<(Mutex<T>, Condvar)>);
+
+#[derive(Eq, PartialEq, Debug)]
+struct NonCopy(i32);
+
+#[test]
+fn smoke() {
+    let m = Mutex::new(());
+    drop(m.lock());
+    drop(m.lock());
+}
+
+#[test]
+fn lots_and_lots() {
+    const J: u32 = 1000;
+    const K: u32 = 3;
+
+    let m = Arc::new(Mutex::new(0));
+
+    fn inc(m: &Mutex<u32>) {
+        for _ in 0..J {
+            *m.lock() += 1;
+        }
+    }
+
+    let (tx, rx) = channel();
+    for _ in 0..K {
+        let tx2 = tx.clone();
+        let m2 = m.clone();
+        thread::spawn(move || {
+            inc(&m2);
+            tx2.send(()).unwrap();
+        });
+        let tx2 = tx.clone();
+        let m2 = m.clone();
+        thread::spawn(move || {
+            inc(&m2);
+            tx2.send(()).unwrap();
+        });
+    }
+
+    drop(tx);
+    for _ in 0..2 * K {
+        rx.recv().unwrap();
+    }
+    assert_eq!(*m.lock(), J * K * 2);
+}
+
+#[test]
+fn try_lock() {
+    let m = Mutex::new(());
+    *m.try_lock().unwrap() = ();
+}
+
+#[test]
+fn test_into_inner() {
+    let m = Mutex::new(NonCopy(10));
+    assert_eq!(m.into_inner(), NonCopy(10));
+}
+
+#[test]
+fn test_into_inner_drop() {
+    struct Foo(Arc<AtomicUsize>);
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+    let num_drops = Arc::new(AtomicUsize::new(0));
+    let m = Mutex::new(Foo(num_drops.clone()));
+    assert_eq!(num_drops.load(Ordering::SeqCst), 0);
+    {
+        let _inner = m.into_inner();
+        assert_eq!(num_drops.load(Ordering::SeqCst), 0);
+    }
+    assert_eq!(num_drops.load(Ordering::SeqCst), 1);
+}
+
+/*
+#[test]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+fn test_into_inner_poison() {
+    let m = Arc::new(Mutex::new(NonCopy(10)));
+    let m2 = m.clone();
+    let _ = thread::spawn(move || {
+        let _lock = m2.lock();
+        panic!("test panic in inner thread to poison mutex");
+    })
+    .join();
+
+    assert!(m.is_poisoned());
+    match Arc::try_unwrap(m).unwrap().into_inner() {
+        Err(e) => assert_eq!(e.into_inner(), NonCopy(10)),
+        Ok(x) => panic!("into_inner of poisoned Mutex is Ok: {x:?}"),
+    }
+}
+*/
+
+#[test]
+fn test_get_mut() {
+    let mut m = Mutex::new(NonCopy(10));
+    *m.get_mut() = NonCopy(20);
+    assert_eq!(m.into_inner(), NonCopy(20));
+}
+
+/*
+#[test]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+fn test_get_mut_poison() {
+    let m = Arc::new(Mutex::new(NonCopy(10)));
+    let m2 = m.clone();
+    let _ = thread::spawn(move || {
+        let _lock = m2.lock();
+        panic!("test panic in inner thread to poison mutex");
+    })
+    .join();
+
+    assert!(m.is_poisoned());
+    match Arc::try_unwrap(m).unwrap().get_mut() {
+        Err(e) => assert_eq!(*e.into_inner(), NonCopy(10)),
+        Ok(x) => panic!("get_mut of poisoned Mutex is Ok: {x:?}"),
+    }
+}
+*/
+
+#[test]
+fn test_mutex_arc_condvar() {
+    let packet = Packet(Arc::new((Mutex::new(false), Condvar::new())));
+    let packet2 = Packet(packet.0.clone());
+    let (tx, rx) = channel();
+    let _t = thread::spawn(move || {
+        // wait until parent gets in
+        rx.recv().unwrap();
+        let &(ref lock, ref cvar) = &*packet2.0;
+        let mut lock = lock.lock();
+        *lock = true;
+        cvar.notify_one();
+    });
+
+    let &(ref lock, ref cvar) = &*packet.0;
+    let mut lock = lock.lock();
+    tx.send(()).unwrap();
+    assert!(!*lock);
+    while !*lock {
+        lock = cvar.wait(lock);
+    }
+}
+
+/*
+#[test]
+fn test_arc_condvar_poison() {
+    let packet = Packet(Arc::new((Mutex::new(1), Condvar::new())));
+    let packet2 = Packet(packet.0.clone());
+    let (tx, rx) = channel();
+
+    let _t = thread::spawn(move || -> () {
+        rx.recv().unwrap();
+        let &(ref lock, ref cvar) = &*packet2.0;
+        let _g = lock.lock();
+        cvar.notify_one();
+        // Parent should fail when it wakes up.
+        panic!();
+    });
+
+    let &(ref lock, ref cvar) = &*packet.0;
+    let mut lock = lock.lock();
+    tx.send(()).unwrap();
+    while *lock == 1 {
+        match cvar.wait(lock) {
+            Ok(l) => {
+                lock = l;
+                assert_eq!(*lock, 1);
+            }
+            Err(..) => break,
+        }
+    }
+}
+*/
+
+/*
+#[test]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+fn test_mutex_arc_poison() {
+    let arc = Arc::new(Mutex::new(1));
+    assert!(!arc.is_poisoned());
+    let arc2 = arc.clone();
+    let _ = thread::spawn(move || {
+        let lock = arc2.lock();
+        assert_eq!(*lock, 2);
+    })
+    .join();
+    assert!(arc.lock().is_err());
+    assert!(arc.is_poisoned());
+}
+
+#[test]
+fn test_mutex_arc_poison_mapped() {
+    let arc = Arc::new(Mutex::new(1));
+    assert!(!arc.is_poisoned());
+    let arc2 = arc.clone();
+    let _ = thread::spawn(move || {
+        let lock = arc2.lock();
+        let lock = MutexGuard::map(lock, |val| val);
+        assert_eq!(*lock, 2); // deliberate assertion failure to poison the mutex
+    })
+    .join();
+    assert!(arc.lock().is_err());
+    assert!(arc.is_poisoned());
+}
+*/
+
+#[test]
+fn test_mutex_arc_nested() {
+    // Tests nested mutexes and access
+    // to underlying data.
+    let arc = Arc::new(Mutex::new(1));
+    let arc2 = Arc::new(Mutex::new(arc));
+    let (tx, rx) = channel();
+    let _t = thread::spawn(move || {
+        let lock = arc2.lock();
+        let lock2 = lock.lock();
+        assert_eq!(*lock2, 1);
+        tx.send(()).unwrap();
+    });
+    rx.recv().unwrap();
+}
+
+#[test]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+fn test_mutex_arc_access_in_unwind() {
+    let arc = Arc::new(Mutex::new(1));
+    let arc2 = arc.clone();
+    let _ = thread::spawn(move || -> () {
+        struct Unwinder {
+            i: Arc<Mutex<i32>>,
+        }
+        impl Drop for Unwinder {
+            fn drop(&mut self) {
+                *self.i.lock() += 1;
+            }
+        }
+        let _u = Unwinder { i: arc2 };
+        panic!();
+    })
+    .join();
+    let lock = arc.lock();
+    assert_eq!(*lock, 2); // deliberate assertion failure to poison the mutex
+}
+
+#[test]
+fn test_mutex_unsized() {
+    let mutex: &Mutex<[i32]> = &Mutex::new([1, 2, 3]);
+    {
+        let b = &mut *mutex.lock();
+        b[0] = 4;
+        b[2] = 5;
+    }
+    let comp: &[i32] = &[4, 2, 5];
+    assert_eq!(&*mutex.lock(), comp);
+}
+
+#[test]
+fn test_mapping_mapped_guard() {
+    let arr = [0; 4];
+    let mut lock = Mutex::new(arr);
+    let guard = lock.lock();
+    let guard = MutexGuard::map(guard, |arr| &mut arr[..2]);
+    let mut guard = MappedMutexGuard::map(guard, |slice| &mut slice[1..]);
+    assert_eq!(guard.len(), 1);
+    guard[0] = 42;
+    drop(guard);
+    assert_eq!(*lock.get_mut(), [0, 42, 0, 0]);
+}
+
+/*
+#[test]
+fn panic_while_mapping_unlocked_poison() {
+    let lock = Mutex::new(());
+
+    let _ = std::panic::catch_unwind(|| {
+        let guard = lock.lock();
+        let _guard = MutexGuard::map::<(), _>(guard, |_| panic!());
+    });
+
+    match lock.try_lock() {
+        Ok(_) => panic!("panicking in a MutexGuard::map closure should poison the Mutex"),
+        Err(TryLockError::WouldBlock) => {
+            panic!("panicking in a MutexGuard::map closure should unlock the mutex")
+        }
+        Err(TryLockError::Poisoned(_)) => {}
+    }
+
+    let _ = std::panic::catch_unwind(|| {
+        let guard = lock.lock();
+        let _guard = MutexGuard::try_map::<(), _>(guard, |_| panic!());
+    });
+
+    match lock.try_lock() {
+        Ok(_) => panic!("panicking in a MutexGuard::try_map closure should poison the Mutex"),
+        Err(TryLockError::WouldBlock) => {
+            panic!("panicking in a MutexGuard::try_map closure should unlock the mutex")
+        }
+        Err(TryLockError::Poisoned(_)) => {}
+    }
+
+    let _ = std::panic::catch_unwind(|| {
+        let guard = lock.lock();
+        let guard = MutexGuard::map::<(), _>(guard, |val| val);
+        let _guard = MappedMutexGuard::map::<(), _>(guard, |_| panic!());
+    });
+
+    match lock.try_lock() {
+        Ok(_) => panic!("panicking in a MappedMutexGuard::map closure should poison the Mutex"),
+        Err(TryLockError::WouldBlock) => {
+            panic!("panicking in a MappedMutexGuard::map closure should unlock the mutex")
+        }
+        Err(TryLockError::Poisoned(_)) => {}
+    }
+
+    let _ = std::panic::catch_unwind(|| {
+        let guard = lock.lock();
+        let guard = MutexGuard::map::<(), _>(guard, |val| val);
+        let _guard = MappedMutexGuard::try_map::<(), _>(guard, |_| panic!());
+    });
+
+    match lock.try_lock() {
+        Ok(_) => panic!("panicking in a MappedMutexGuard::try_map closure should poison the Mutex"),
+        Err(TryLockError::WouldBlock) => {
+            panic!("panicking in a MappedMutexGuard::try_map closure should unlock the mutex")
+        }
+        Err(TryLockError::Poisoned(_)) => {}
+    }
+
+    drop(lock);
+}
+*/

--- a/tests/shm/sync_rwlock.rs
+++ b/tests/shm/sync_rwlock.rs
@@ -1,0 +1,502 @@
+//! The following is derived from Rust's
+//! library/std/src/sync/rwlock/tests.rs at revision
+//! 3ef4b083ac03fd25339be009e3ae525adab30d78.
+
+use rand::{self, Rng};
+use rustix_futex_sync::shm::{RwLock, RwLockReadGuard, MappedRwLockReadGuard, RwLockWriteGuard, MappedRwLockWriteGuard};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc::channel;
+use std::sync::Arc;
+use std::thread;
+
+#[derive(Eq, PartialEq, Debug)]
+struct NonCopy(i32);
+
+#[test]
+fn smoke() {
+    let l = RwLock::new(());
+    drop(l.read());
+    drop(l.write());
+    drop((l.read(), l.read()));
+    drop(l.write());
+}
+
+#[test]
+fn frob() {
+    const N: u32 = 10;
+    const M: usize = if cfg!(miri) { 100 } else { 1000 };
+
+    let r = Arc::new(RwLock::new(()));
+
+    let (tx, rx) = channel::<()>();
+    for _ in 0..N {
+        let tx = tx.clone();
+        let r = r.clone();
+        thread::spawn(move || {
+            let mut rng = rand::thread_rng();
+            for _ in 0..M {
+                if rng.gen_bool(1.0 / (N as f64)) {
+                    drop(r.write());
+                } else {
+                    drop(r.read());
+                }
+            }
+            drop(tx);
+        });
+    }
+    drop(tx);
+    let _ = rx.recv();
+}
+
+/*
+#[test]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+fn test_rw_arc_poison_wr() {
+    let arc = Arc::new(RwLock::new(1));
+    let arc2 = arc.clone();
+    let _: Result<(), _> = thread::spawn(move || {
+        let _lock = arc2.write();
+        panic!();
+    })
+    .join();
+    assert!(arc.read().is_err());
+}
+
+#[test]
+fn test_rw_arc_poison_mapped_w_r() {
+    let arc = Arc::new(RwLock::new(1));
+    let arc2 = arc.clone();
+    let _: Result<(), _> = thread::spawn(move || {
+        let lock = arc2.write();
+        let _lock = RwLockWriteGuard::map(lock, |val| val);
+        panic!();
+    })
+    .join();
+    assert!(arc.read().is_err());
+}
+
+#[test]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+fn test_rw_arc_poison_ww() {
+    let arc = Arc::new(RwLock::new(1));
+    assert!(!arc.is_poisoned());
+    let arc2 = arc.clone();
+    let _: Result<(), _> = thread::spawn(move || {
+        let _lock = arc2.write();
+        panic!();
+    })
+    .join();
+    assert!(arc.write().is_err());
+    assert!(arc.is_poisoned());
+}
+
+#[test]
+fn test_rw_arc_poison_mapped_w_w() {
+    let arc = Arc::new(RwLock::new(1));
+    let arc2 = arc.clone();
+    let _: Result<(), _> = thread::spawn(move || {
+        let lock = arc2.write();
+        let _lock = RwLockWriteGuard::map(lock, |val| val);
+        panic!();
+    })
+    .join();
+    assert!(arc.write().is_err());
+    assert!(arc.is_poisoned());
+}
+
+#[test]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+fn test_rw_arc_no_poison_rr() {
+    let arc = Arc::new(RwLock::new(1));
+    let arc2 = arc.clone();
+    let _: Result<(), _> = thread::spawn(move || {
+        let _lock = arc2.read();
+        panic!();
+    })
+    .join();
+    let lock = arc.read();
+    assert_eq!(*lock, 1);
+}
+
+#[test]
+fn test_rw_arc_no_poison_mapped_r_r() {
+    let arc = Arc::new(RwLock::new(1));
+    let arc2 = arc.clone();
+    let _: Result<(), _> = thread::spawn(move || {
+        let lock = arc2.read();
+        let _lock = RwLockReadGuard::map(lock, |val| val);
+        panic!();
+    })
+    .join();
+    let lock = arc.read();
+    assert_eq!(*lock, 1);
+}
+
+#[test]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+fn test_rw_arc_no_poison_rw() {
+    let arc = Arc::new(RwLock::new(1));
+    let arc2 = arc.clone();
+    let _: Result<(), _> = thread::spawn(move || {
+        let _lock = arc2.read();
+        panic!()
+    })
+    .join();
+    let lock = arc.write();
+    assert_eq!(*lock, 1);
+}
+
+#[test]
+fn test_rw_arc_no_poison_mapped_r_w() {
+    let arc = Arc::new(RwLock::new(1));
+    let arc2 = arc.clone();
+    let _: Result<(), _> = thread::spawn(move || {
+        let lock = arc2.read();
+        let _lock = RwLockReadGuard::map(lock, |val| val);
+        panic!();
+    })
+    .join();
+    let lock = arc.write();
+    assert_eq!(*lock, 1);
+}
+*/
+
+#[test]
+fn test_rw_arc() {
+    let arc = Arc::new(RwLock::new(0));
+    let arc2 = arc.clone();
+    let (tx, rx) = channel();
+
+    thread::spawn(move || {
+        let mut lock = arc2.write();
+        for _ in 0..10 {
+            let tmp = *lock;
+            *lock = -1;
+            thread::yield_now();
+            *lock = tmp + 1;
+        }
+        tx.send(()).unwrap();
+    });
+
+    // Readers try to catch the writer in the act
+    let mut children = Vec::new();
+    for _ in 0..5 {
+        let arc3 = arc.clone();
+        children.push(thread::spawn(move || {
+            let lock = arc3.read();
+            assert!(*lock >= 0);
+        }));
+    }
+
+    // Wait for children to pass their asserts
+    for r in children {
+        assert!(r.join().is_ok());
+    }
+
+    // Wait for writer to finish
+    rx.recv().unwrap();
+    let lock = arc.read();
+    assert_eq!(*lock, 10);
+}
+
+#[test]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+fn test_rw_arc_access_in_unwind() {
+    let arc = Arc::new(RwLock::new(1));
+    let arc2 = arc.clone();
+    let _ = thread::spawn(move || -> () {
+        struct Unwinder {
+            i: Arc<RwLock<isize>>,
+        }
+        impl Drop for Unwinder {
+            fn drop(&mut self) {
+                let mut lock = self.i.write();
+                *lock += 1;
+            }
+        }
+        let _u = Unwinder { i: arc2 };
+        panic!();
+    })
+    .join();
+    let lock = arc.read();
+    assert_eq!(*lock, 2);
+}
+
+#[test]
+fn test_rwlock_unsized() {
+    let rw: &RwLock<[i32]> = &RwLock::new([1, 2, 3]);
+    {
+        let b = &mut *rw.write();
+        b[0] = 4;
+        b[2] = 5;
+    }
+    let comp: &[i32] = &[4, 2, 5];
+    assert_eq!(&*rw.read(), comp);
+}
+
+#[test]
+fn test_rwlock_try_write() {
+    let lock = RwLock::new(0isize);
+    let read_guard = lock.read();
+
+    let write_result = lock.try_write();
+    match write_result {
+        None => (),
+        Some(_) => assert!(
+            false,
+            "try_write should not succeed while read_guard is in scope"
+        ),
+    }
+
+    drop(read_guard);
+    let mapped_read_guard = RwLockReadGuard::map(lock.read(), |_| &());
+
+    let write_result = lock.try_write();
+    match write_result {
+        None => (),
+        Some(_) => assert!(false, "try_write should not succeed while mapped_read_guard is in scope"),
+    }
+
+    drop(mapped_read_guard);
+}
+
+#[test]
+fn test_into_inner() {
+    let m = RwLock::new(NonCopy(10));
+    assert_eq!(m.into_inner(), NonCopy(10));
+}
+
+#[test]
+fn test_into_inner_drop() {
+    struct Foo(Arc<AtomicUsize>);
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+    let num_drops = Arc::new(AtomicUsize::new(0));
+    let m = RwLock::new(Foo(num_drops.clone()));
+    assert_eq!(num_drops.load(Ordering::SeqCst), 0);
+    {
+        let _inner = m.into_inner();
+        assert_eq!(num_drops.load(Ordering::SeqCst), 0);
+    }
+    assert_eq!(num_drops.load(Ordering::SeqCst), 1);
+}
+
+/*
+#[test]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+fn test_into_inner_poison() {
+    let m = Arc::new(RwLock::new(NonCopy(10)));
+    let m2 = m.clone();
+    let _ = thread::spawn(move || {
+        let _lock = m2.write().unwrap();
+        panic!("test panic in inner thread to poison RwLock");
+    })
+    .join();
+
+    assert!(m.is_poisoned());
+    match Arc::try_unwrap(m).unwrap().into_inner() {
+        Err(e) => assert_eq!(e.into_inner(), NonCopy(10)),
+        Ok(x) => panic!("into_inner of poisoned RwLock is Ok: {x:?}"),
+    }
+}
+*/
+
+#[test]
+fn test_get_mut() {
+    let mut m = RwLock::new(NonCopy(10));
+    *m.get_mut() = NonCopy(20);
+    assert_eq!(m.into_inner(), NonCopy(20));
+}
+
+/*
+#[test]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+fn test_get_mut_poison() {
+    let m = Arc::new(RwLock::new(NonCopy(10)));
+    let m2 = m.clone();
+    let _ = thread::spawn(move || {
+        let _lock = m2.write();
+        panic!("test panic in inner thread to poison RwLock");
+    })
+    .join();
+
+    assert!(m.is_poisoned());
+    match Arc::try_unwrap(m).unwrap().get_mut() {
+        Err(e) => assert_eq!(*e.into_inner(), NonCopy(10)),
+        Ok(x) => panic!("get_mut of poisoned RwLock is Ok: {x:?}"),
+    }
+}
+*/
+
+/* // `lock_api`'s `RwLockReadGuard` does not appear to support covariance.
+#[test]
+fn test_read_guard_covariance() {
+    fn do_stuff<'a>(_: RwLockReadGuard<'_, &'a i32>, _: &'a i32) {}
+    let j: i32 = 5;
+    let lock = RwLock::new(&j);
+    {
+        let i = 6;
+        do_stuff(lock.read(), &i);
+    }
+    drop(lock);
+}
+*/
+
+#[test]
+fn test_mapped_read_guard_covariance() {
+    fn do_stuff<'a>(_: MappedRwLockReadGuard<'_, &'a i32>, _: &'a i32) {}
+    let j: i32 = 5;
+    let lock = RwLock::new((&j, &j));
+    {
+        let i = 6;
+        let guard = lock.read();
+        let guard = RwLockReadGuard::map(guard, |(val, _val)| val);
+        do_stuff(guard, &i);
+    }
+    drop(lock);
+}
+
+#[test]
+fn test_mapping_mapped_guard() {
+    let arr = [0; 4];
+    let mut lock = RwLock::new(arr);
+    let guard = lock.write();
+    let guard = RwLockWriteGuard::map(guard, |arr| &mut arr[..2]);
+    let mut guard = MappedRwLockWriteGuard::map(guard, |slice| &mut slice[1..]);
+    assert_eq!(guard.len(), 1);
+    guard[0] = 42;
+    drop(guard);
+    assert_eq!(*lock.get_mut(), [0, 42, 0, 0]);
+
+    let guard = lock.read();
+    let guard = RwLockReadGuard::map(guard, |arr| &arr[..2]);
+    let guard = MappedRwLockReadGuard::map(guard, |slice| &slice[1..]);
+    assert_eq!(*guard, [42]);
+    drop(guard);
+    assert_eq!(*lock.get_mut(), [0, 42, 0, 0]);
+}
+
+/* // `RwLock` contains an `UnsafeCell` which can't be transferred across a `catch_unwind` boundary.
+#[test]
+fn panic_while_mapping_read_unlocked_no_poison() {
+    let lock = RwLock::new(());
+
+    let _ = std::panic::catch_unwind(|| {
+        let guard = lock.read();
+        let _guard = RwLockReadGuard::map::<(), _>(guard, |_| panic!());
+    });
+
+    match lock.try_write() {
+        Some(_) => {}
+        None => {
+            panic!("panicking in a RwLockReadGuard::map closure should release the read lock")
+        }
+    }
+
+    let _ = std::panic::catch_unwind(|| {
+        let guard = lock.read();
+        let _guard = RwLockReadGuard::try_map::<(), _>(guard, |_| panic!());
+    });
+
+    match lock.try_write() {
+        Some(_) => {}
+        None => {
+            panic!("panicking in a RwLockReadGuard::try_map closure should release the read lock")
+        }
+    }
+
+    let _ = std::panic::catch_unwind(|| {
+        let guard = lock.read();
+        let guard = RwLockReadGuard::map::<(), _>(guard, |val| val);
+        let _guard = MappedRwLockReadGuard::map::<(), _>(guard, |_| panic!());
+    });
+
+    match lock.try_write() {
+        Some(_) => {}
+        None => {
+            panic!("panicking in a MappedRwLockReadGuard::map closure should release the read lock")
+        }
+    }
+
+    let _ = std::panic::catch_unwind(|| {
+        let guard = lock.read();
+        let guard = RwLockReadGuard::map::<(), _>(guard, |val| val);
+        let _guard = MappedRwLockReadGuard::try_map::<(), _>(guard, |_| panic!());
+    });
+
+    match lock.try_write() {
+        Some(_) => {}
+        None => panic!(
+            "panicking in a MappedRwLockReadGuard::try_map closure should release the read lock"
+        ),
+    }
+
+    drop(lock);
+}
+
+#[test]
+fn panic_while_mapping_write_unlocked_poison() {
+    let lock = RwLock::new(());
+
+    let _ = std::panic::catch_unwind(|| {
+        let guard = lock.write();
+        let _guard = RwLockWriteGuard::map::<(), _>(guard, |_| panic!());
+    });
+
+    match lock.try_write() {
+        Some(_) => panic!("panicking in a RwLockWriteGuard::map closure should poison the RwLock"),
+        None => {
+            panic!("panicking in a RwLockWriteGuard::map closure should release the write lock")
+        }
+    }
+
+    let _ = std::panic::catch_unwind(|| {
+        let guard = lock.write();
+        let _guard = RwLockWriteGuard::try_map::<(), _>(guard, |_| panic!());
+    });
+
+    match lock.try_write() {
+        Some(_) => {
+            panic!("panicking in a RwLockWriteGuard::try_map closure should poison the RwLock")
+        }
+        None => {
+            panic!("panicking in a RwLockWriteGuard::try_map closure should release the write lock")
+        }
+    }
+
+    let _ = std::panic::catch_unwind(|| {
+        let guard = lock.write();
+        let guard = RwLockWriteGuard::map::<(), _>(guard, |val| val);
+        let _guard = MappedRwLockWriteGuard::map::<(), _>(guard, |_| panic!());
+    });
+
+    match lock.try_write() {
+        Some(_) => {
+            panic!("panicking in a MappedRwLockWriteGuard::map closure should poison the RwLock")
+        }
+        None => panic!(
+            "panicking in a MappedRwLockWriteGuard::map closure should release the write lock"
+        ),
+    }
+
+    let _ = std::panic::catch_unwind(|| {
+        let guard = lock.write();
+        let guard = RwLockWriteGuard::map::<(), _>(guard, |val| val);
+        let _guard = MappedRwLockWriteGuard::try_map::<(), _>(guard, |_| panic!());
+    });
+
+    match lock.try_write() {
+        Some(_) => panic!(
+            "panicking in a MappedRwLockWriteGuard::try_map closure should poison the RwLock"
+        ),
+        None => panic!(
+            "panicking in a MappedRwLockWriteGuard::try_map closure should release the write lock"
+        ),
+    }
+
+    drop(lock);
+}
+*/


### PR DESCRIPTION
Add a "shm" feature which enables a `sym` module which exposes shared-memory-supporting versions of all the main public types.

Fixes #15.